### PR TITLE
gpkg-dev/glibc: fix mprotect (again)

### DIFF
--- a/gpkg-dev/glibc/PKGBUILD
+++ b/gpkg-dev/glibc/PKGBUILD
@@ -3,8 +3,7 @@
 
 pkgname=glibc
 pkgver=2.37
-pkgrel=10
-_commit=be176490b818b65b5162c332eb6b581690b16e5c
+pkgrel=11
 pkgdesc="GNU C Library"
 arch=(any)
 url='https://www.gnu.org/software/libc/'
@@ -83,7 +82,7 @@ sha256sums=('2257eff111a1815d74f46856daaf40b019c1e553156c69d48ba0cbfc1bb91a43'
             '6a63b915b8f50e05a9a2287241e907f0c2a2b39f8d696c18a3e23267805d6a92'
             'f29c92c48adae65e86256b4ae5180c77aa6957d90bbc7abb54042c2820b2a26f'
             'e378b410d1f1750b7751910dffcd525f58be71ab1b4f54a09e1eedd7fa3829f4'
-            '8951c11eb881bf3da35146986cacd321dfb9f6d776dc620304f64251cc185b12')
+            '27be199f7d469a44a9b840dac7275968761082d4735cc27326b5bca81bfce2b8')
 groups=('gpkg-dev')
 
 prepare() {

--- a/gpkg-dev/glibc/mprotect.c
+++ b/gpkg-dev/glibc/mprotect.c
@@ -15,14 +15,14 @@
 int __mprotect(void *addr, size_t len, int prot) {
 #if !IS_IN(rtld)
 	if (prot & PROT_EXEC) {
-		void *caddr = malloc(sizeof(addr));
+		void *caddr = malloc(len);
 		if (caddr == NULL)
 			return errno;
-		memcpy(caddr, addr, sizeof(addr));
+		memcpy(caddr, addr, len);
 		addr = mmap(addr, len, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
 		if (__glibc_unlikely(addr == MAP_FAILED))
 			return errno;
-		memcpy(addr, caddr, sizeof(caddr));
+		memcpy(addr, caddr, len);
 		free(caddr);
 		return 0;
 	}


### PR DESCRIPTION
![Screenshot_20230724_235750_Termux](https://github.com/termux-pacman/glibc-packages/assets/60917834/01723163-4eb8-40c5-8071-f37da9d25f27)
