### PR TITLE
pulseaudio: clean up

### DIFF
--- a/gpkg/libpulse/build.sh
+++ b/gpkg/libpulse/build.sh
@@ -4,18 +4,45 @@ TERMUX_PKG_LICENSE="GPL-2.0"
 TERMUX_PKG_MAINTAINER="@termux-pacman"
 TERMUX_PKG_SRCURL="git+https://github.com/pulseaudio/pulseaudio"
 TERMUX_PKG_VERSION="17.0"
-TERMUX_PKG_DEPENDS="libsndfile-glibc, libltdl-glibc, gdbm-glibc, libxcb-glibc, libxtst-glibc, libsm-glibc, libtool-glibc, libcap-glibc, dbus-glibc"
+TERMUX_PKG_REVISION=1
+# The old variables will be used again when the daemon is configured in pulseaudio-glibs
+#TERMUX_PKG_DEPENDS="libsndfile-glibc, libltdl-glibc, gdbm-glibc, libxcb-glibc, libxtst-glibc, libsm-glibc, libtool-glibc, libcap-glibc, dbus-glibc"
+TERMUX_PKG_DEPENDS="libsndfile-glibc, dbus-glibc, pulseaudio"
 TERMUX_PKG_BUILD_DEPENDS="gettext-glibc"
-TERMUX_PKG_CONFFILES="glibc/etc/pulse/client.conf, glibc/etc/pulse/daemon.conf, glibc/etc/pulse/default.pa, glibc/etc/pulse/system.pa"
+#TERMUX_PKG_CONFFILES="glibc/etc/pulse/client.conf, glibc/etc/pulse/daemon.conf, glibc/etc/pulse/default.pa, glibc/etc/pulse/system.pa"
+TERMUX_PKG_CONFFILES="glibc/etc/pulse/client.conf"
+
+# TODO: learn android audio system
 
 # manpages generation requires perl's XML::Parser.
 # pulseaudio daemon is useless on glibc,
 # because it cannot use system sound libraries.
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-Ddaemon=false
 -Dman=false
 -Dtests=false
 -Ddatabase=gdbm
 -Dx11=enabled
 "
 
-# Maxython: I need to learn how the audio driver works in Android in order to configure glibc
+termux_step_post_make_install() {
+	install -m755 ${TERMUX_PKG_BUILDER_DIR}/pulseaudio-start.sh ${TERMUX_PREFIX}/bin/pulseaudio-start
+	sed -i -e "s|@TERMUX_PREFIX_CLASSICAL@|$TERMUX_PREFIX_CLASSICAL|g" \
+		-e "s|@TERMUX_PREFIX@|$TERMUX_PREFIX|g" \
+		${TERMUX_PREFIX}/bin/pulseaudio-start
+}
+
+termux_step_create_debscripts() {
+	cat <<- EOF > ./postinst
+	#!$TERMUX_PREFIX_CLASSICAL/bin/sh
+	echo
+	echo "== Warning =="
+	echo "pulseaudio-glibc does not support deamon,"
+	echo "it works with pulseaudio based on bionic."
+	echo
+	EOF
+
+	if [ "$TERMUX_PACKAGE_FORMAT" = "pacman" ]; then
+		echo "post_install" > postupg
+	fi
+}

--- a/gpkg/libpulse/pulseaudio-start.sh
+++ b/gpkg/libpulse/pulseaudio-start.sh
@@ -1,0 +1,28 @@
+#!@TERMUX_PREFIX@/bin/bash
+
+# A simple script that simplifies the configuration of pulseaudio-glibc
+
+unset LD_PRELOAD
+unset PULSE_SERVER
+
+PA_IP="127.0.0.1"
+
+pa_pid=$(pidof "@TERMUX_PREFIX_CLASSICAL@/bin/pulseaudio")
+if [ -n "${pa_pid}" ]; then
+	kill ${pa_pid}
+fi
+
+if [ "${1}" = "-kill" ] || [ "${1}" = "-k" ]; then
+	if [ -n "${pa_pid}" ]; then
+		echo "pulseaudio was stopped successfully"
+	fi
+	exit 0
+fi
+
+@TERMUX_PREFIX_CLASSICAL@/bin/pulseaudio --start --exit-idle-time=-1 || exit 1
+@TERMUX_PREFIX_CLASSICAL@/bin/pacmd load-module module-native-protocol-tcp auth-ip-acl=${PA_IP} auth-anonymous=1 || exit 1
+
+echo "To make pulseaudio-glibc work, copy and paste this command into your shell:"
+echo
+echo " export PULSE_SERVER=${PA_IP}"
+echo


### PR DESCRIPTION
This brings the package to be more inline with the bionic package, mainly disabling the daemon component as it isn't useful and instead relying on the bionic server.

Note: When XDG_RUNTIME_DIR isn't specified, pulseaudio calls a seeded `rand` to decide on a runtime directory. This means the glibc client won't find the server by default as the two libcs' `rand` are different.