### PR TITLE
mandb: new packet the default Debian man pager with search function etc

### DIFF
--- a/gpkg/libpipeline/build.sh
+++ b/gpkg/libpipeline/build.sh
@@ -1,0 +1,9 @@
+TERMUX_PKG_HOMEPAGE=http://libpipeline.nongnu.org/
+TERMUX_PKG_DESCRIPTION="C library for manipulating pipelines of subprocesses in a flexible and convenient way"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=1.5.8
+TERMUX_PKG_SRCURL=https://download.savannah.nongnu.org/releases/libpipeline/libpipeline-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=1b1203ca152ccd63983c3f2112f7fe6fa5afd453218ede5153d1b31e11bb8405
+TERMUX_PKG_BREAKS="libpipeline-dev"
+TERMUX_PKG_REPLACES="libpipeline-dev"

--- a/gpkg/mandb/build.sh
+++ b/gpkg/mandb/build.sh
@@ -1,0 +1,46 @@
+TERMUX_PKG_DESCRIPTION="mandb manual reader "
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_VERSION=0
+TERMUX_PKG_SRCURL=git+https://gitlab.com/man-db/man-db
+TERMUX_PKG_GIT_BRANCH=main
+TERMUX_PKG_DEPENDS="gdbm-glibc, glibc, libpipeline-glibc"
+# TERMUX_PKG_BUILD_DEPENDS="less, libandroid-glob, zlib"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --with-systemdsystemunitdir=no --with-systemdtmpfilesdir=no --disable-makeinstall-chown  ac_cv_func_chown=no " 
+TERMUX_PKG_EXTRA_MAKE_ARGS=" V=1 VERBOSE=1 -j4 " 
+
+termux_step_pre_configure() {
+	# this server is down with 502 hosting problems using mirror instead 
+	sed -i s,git.savannah.gnu.org/git/gnulib.git,github.com/mirror/gnulib, bootstrap
+	# sed -i '1 a\set -x' bootstrap
+	bootstrap
+	# autogen --force
+	# sed -i '1 a\set -x' configure
+	# export MAKEFLAGS=-j4
+	{
+			echo "HAVE_CHOWN=0"
+	} > configure.local
+# :
+}
+
+# termux_step_configure() {
+# 	pwd
+# 	cd $TERMUX_PKG_SRCDIR
+# 	configure
+# }
+
+
+termux_step_post_configure() {
+	sed -i "s, install-exec-hook,," src/Makefile
+# read -p yes?
+}
+
+termux_step_post_make_install() {
+	cd $TERMUX_PREFIX/bin
+	mv man mman
+	mv whatis mwhatis
+}
+
+termux_step_post_massage() {
+	mkdir -p glibc/etc
+	echo "MANDATORY_MANPATH	$TERMUX_PREFIX/share/man" > glibc/etc/man_db.conf
+}


### PR DESCRIPTION
I wanted to use the search function that I have not found in man doc.
but this manual page is missing it should come with ncurses

~~~

mman -K initp <- search for string
man 5 terminfo <- where is you
~~~

this is from Debian
~~~
apt-file find $PREFIX/share/man/man5/terminfo.5.gz
ncurses-bin: /usr/share/man/man5/terminfo.5.gz
~~~

 # future plans
I will add apt next and tmux and try to move my default shell to GNU
libc I am sick of bionic errors. my goal is to have a stand alone repo
with no reference to bionic in $DATA/glibc=/data/data/abc/glibc with  DATA
the root for Debian Sid also in $DATA/debian. that use
/ld-linux-aarch64.so.1 from glibc and proot. my approach is different
from proot distro I don't pre download anything everything comes from
apt from the root packet gcc-14-base and up

 and finally $DATA/bionic
that I hope I won't need
