### PR TITLE
curl  impersonate FIXED trying to restore stack exchange (still broken )

### DIFF
--- a/gpkg/boringssl/build.sh
+++ b/gpkg/boringssl/build.sh
@@ -1,0 +1,47 @@
+TERMUX_PKG_SRCURL=git+https://github.com/john-peterson/boringssl
+TERMUX_PKG_GIT_BRANCH=imp
+
+# TERMUX_PKG_SRCURL=git+https://github.com/google/boringssl
+# TERMUX_PKG_GIT_BRANCH=main
+
+TERMUX_PKG_DESCRIPTION="boring ssl"
+TERMUX_PKG_VERSION=0
+TERMUX_PKG_LICENSE="Apache-2.0"
+TERMUX_PKG_BUILD_DEPENDS="golang"
+# TERMUX_PKG_DEPENDS="libnghttp2, libnghttp3, libssh2, openssl (>= 1:3.2.1-1), zlib"
+TERMUX_PKG_DEPENDS="ca-certificates, zlib-glibc"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" -DCMAKE_INSTALL_PREFIX=$TERMUX_PREFIX/opt/boringssl -DCMAKE_INSTALL_LIBDIR=$TERMUX_PREFIX/opt/boringssl/lib -DBUILD_SHARED_LIBS=ON"
+# TERMUX_PKG_EXTRA_MAKE_ARGS=" -j2 "
+TERMUX_PKG_MAKE_PROCESSES=2
+
+termux_step_pre_configure() {
+export CXXFLAGS="-w -Wno-error"
+# export CFLAGS=-fno-exceptions
+	sed -i "s,-Werror,,g" CMakeLists.txt
+:
+}
+
+# termux_step_configure() { :; }
+
+termux_step_post_configure() {
+	sed -i "s,-Werror ,,g" ../build/build.ninja
+: 
+}
+
+# termux_step_make() { 
+
+# }
+
+
+termux_step_post_make_install() {
+	# mkdir $TERMUX_PREFIX/opt/boringssl
+	# mv $TERMUX_PREFIX/lib/libcrypto.so $TERMUX_PREFIX/opt/boringssl
+	# mv $TERMUX_PREFIX/lib/libssl.so $TERMUX_PREFIX/opt/boringssl
+	:
+}
+
+# termux_step_extract_into_massagedir() { :; }
+
+# termux_step_post_massage() { :; }
+
+

--- a/gpkg/curl-impersonate/build.sh
+++ b/gpkg/curl-impersonate/build.sh
@@ -1,0 +1,73 @@
+# this insane script tries to build brotli and fail
+TERMUX_PKG_SRCURL=git+https://github.com/lexiforest/curl-impersonate
+# TERMUX_PKG_SRCURL=git+https://github.com/lwthiker/curl-impersonate
+TERMUX_PKG_GIT_BRANCH=main
+# TERMUX_PKG_BUILD_IN_SRC=true
+
+#to-do fix this proper build 
+TERMUX_PKG_SRCURL=git+https://github.com/john-peterson/curl
+TERMUX_PKG_GIT_BRANCH=imp
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DUSE_NGHTTP2=ON
+-DCURL_BROTLI=ON
+-DCURL_USE_LIBPSL=OFF
+-DOPENSSL_ROOT_DIR=$TERMUX_PREFIX/opt/boringssl -DBUILD_SHARED_LIBS=ON
+-DCMAKE_INSTALL_PREFIX=$TERMUX_PREFIX/opt/curl-impersonate
+-DCMAKE_INSTALL_LIBDIR=$TERMUX_PREFIX/opt/curl-impersonate/lib
+-DCURL_CA_PATH=$TERMUX_PREFIX/etc/ssl/certs
+-DCURL_CA_BUNDLE=$TERMUX_PREFIX/etc/ssl/certs/ca-certificates.crt
+"
+# -DCMAKE_CXX_FLAGS:=-fno-exceptions
+
+TERMUX_PKG_DESCRIPTION="curl impersonation for curl_cffi"
+TERMUX_PKG_VERSION=8.13.0
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_BUILD_DEPENDS="golang"
+TERMUX_PKG_DEPENDS="  brotli-glibc, libnghttp2-glibc, zlib-glibc, zstd-glibc"
+# TERMUX_PKG_DEPENDS=" boringssl-glibc, libnghttp2-glibc, libnghttp3-glibc, libssh2-glibc"
+
+# TERMUX_PKG_EXTRA_MAKE_ARGS=" -j4 "
+TERMUX_PKG_MAKE_PROCESSES=4
+
+termux_step_pre_configure() {
+# export CXXFLAGS=-fno-exceptions
+# export CFLAGS=-fno-exceptions
+:
+}
+
+# termux_step_configure() {
+# 	configure
+# }
+
+termux_step_post_configure() {
+	# ack fno-exc build.ninja || exit
+	# exit
+: 
+}
+
+# termux_step_make() { 
+# export MAKEFLAGS=-j4
+# make chrome-build -C ../build
+# sed -i '/unzip/i \\tpwd\n\tls' Makefile
+# ack -C pwd Makefile
+# exit
+# make chrome-build 
+# make build
+# }
+
+# termux_step_make_install() {
+	# mkdir -p $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/lib
+	# cp $TERMUX_PKG_BUILDDIR/* $TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/lib/
+	# :;
+# }
+
+termux_step_post_make_install() {
+# 	mv $TERMUX_PREFIX/opt/curl-impersonate/bin/curl $TERMUX_PREFIX/bin/curl-impersonate
+	patchelf --set-rpath $TERMUX_PREFIX/opt/boringssl/lib:$TERMUX_PREFIX/opt/curl-impersonate/lib $TERMUX_PREFIX/opt/curl-impersonate/bin/curl
+}
+
+# termux_step_extract_into_massagedir() { :; }
+
+# termux_step_post_massage() { :; }
+
+


### PR DESCRIPTION
UPDATE build is fixed now was just massive confusion with so many
different libs. and files. please merge this into curl

~~~
$P/glibc/opt/curl-impersonate/bin/curl "$@" --cacert $G/etc/ssl/certs/ca-certificates.crt
~~~

managed to get cloud flare cookie with this tool but
page still won't load it essentially insanity they HAVE to provide a
text based challenge this is complete utter insanity

https://github.com/LOBYXLYX/Cloudflare-Bypass

---

today stack exchange effectively started blocking all terminal browsers  by
enforcing cf_clearance cookie. the mobile browser has no interactive
verification but termux Firefox force interaction

 this has to be fixed it
is impossible to have stack exchange off line inside the terminal it
takes ages to open links outside the terminal. usually the cookie only
last a few minutes and then you need to open Firefox again absolute
insanity. I get sick outside the terminal I can't stand it my life is in
text only

stack exchange has no official text interface and this effectively broke
socli and all other I work on

~~~sh
url=https://stackoverflow.com/questions/57568571/android-studio-javax-net-ssl-sslhandshakeexception-unacceptable-certificate

links -dump $url|vim - -R
Enable JavaScript and cookies to continue

chromium-browser --headless --disable-gpu --dump-dom $url | lynx -stdin -dump|vim - -R
Verifying you are human. This may take a few seconds.
Performance & security by [2]Cloudflare

firefox $url <- important CLOSE Firefox otherwise no cookie
echo "select * from moz_cookies"|sqlite3 ~/.mozilla/firefox/*.default-default/cookies.sqlite |ack cf_clear|  grep -o -P '(?<=cf_clearance\|).*(?=\|.stack)'
~~~

even curl impersonate can't get past the new blockade any ideas have you
used any automatic cf_clearance collector

~~~
from curl_cffi import requests
url="https://stackoverflow.com/questions/57568571"
r = requests.get(url, impersonate=browser)
print(r.content)

Enable JavaScript and cookies to continue
~~~

~~~
https://github.com/lwthiker/curl-impersonate/releases/download/v0.6.1/curl-impersonate-v0.6.1.x86_64-linux-gnu.tar.gz
curl_chrome116 $url -s  | lynx -stdin -dump | vim - -R
Enable JavaScript and cookies to continue
~~~

while I think about this I tried to build it but it failed. I have to
ask them if there is any solution for stack exchange they have figured
out without leaving the terminal

 # his build was broken

this did not work in termux

~~~
https://github.com/lwthiker/curl-impersonate/releases/download/v0.6.1/curl-impersonate-v0.6.1.arm-linux-gnueabihf.tar.gz
glibc-runner -c curl-impersonate-chrome
ld-linux-armhf.so.3 => not found
~~~

 # Insane script failed

the script can't build brotli.

~~~
make chrome-build
file INSTALL cannot find
  "/home/a/.termux-build/curl-impersonate-glibc/src/brotli-1.0.9/out/libbrotlidec.so.1.0.9":
~~~