### PR TITLE
apt: for glibc repos only no bionic repos.  no path patches

### DIFF
--- a/gpkg/apt/apt.conf.in
+++ b/gpkg/apt/apt.conf.in
@@ -1,0 +1,5 @@
+// vim:ft=aptconf
+Acquire::https::CaInfo "@TERMUX_PREFIX@/etc/ssl/certs/ca-certificates.crt";.
+APT::Architecture "aarch64";
+APT::Clean-Installed "0";
+APT::Install-Recommends "0";

--- a/gpkg/apt/build.sh
+++ b/gpkg/apt/build.sh
@@ -1,0 +1,112 @@
+TERMUX_PKG_HOMEPAGE=https://packages.debian.org/apt
+TERMUX_PKG_DESCRIPTION="Front-end for the dpkg package manager"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="2.8.1"
+TERMUX_PKG_REVISION=1
+# old tarball are removed in https://deb.debian.org/debian/pool/main/a/apt/apt_${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SRCURL=https://salsa.debian.org/apt-team/apt/-/archive/${TERMUX_PKG_VERSION}/apt-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=87ca18392c10822a133b738118505f7d04e0b31ba1122bf5d32911311cb2dc7e
+# apt-key requires utilities from coreutils, findutils, gpgv, grep, sed.
+# TERMUX_PKG_DEPENDS="coreutils, dpkg, findutils, gpgv, grep, libbz2, libc++, libiconv, libgcrypt, libgnutls, liblz4, liblzma, sed, xxhash, zlib, zstd"
+TERMUX_PKG_DEPENDS="coreutils-glibc, dpkg-glibc, findutils, gpgv, grep, libbz2-glibc, libc++, libiconv-glibc, libgcrypt-glibc, libgnutls-glibc, liblz4-glibc, liblzma-glibc, sed, xxhash-glibc, zlib-glibc, zstd-glibc"
+# TERMUX_PKG_DEPENDS="libbz2-glibc, zlib-glibc"
+# termux-licenses, termux-keyring
+TERMUX_PKG_BUILD_DEPENDS="docbook-xsl, libdb-glibc"
+# TERMUX_PKG_CONFLICTS="apt-transport-https, libapt-pkg, unstable-repo, game-repo, science-repo"
+# TERMUX_PKG_REPLACES="apt-transport-https, libapt-pkg, unstable-repo, game-repo, science-repo"
+# TERMUX_PKG_PROVIDES="unstable-repo, game-repo, science-repo"
+TERMUX_PKG_SUGGESTS="proot"
+# TERMUX_PKG_ESSENTIAL=true
+
+TERMUX_PKG_CONFFILES="
+etc/apt/sources.list
+"
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+-DPERL_EXECUTABLE=$(command -v perl)
+-DCOMMON_ARCH=$TERMUX_ARCH
+-DUSE_NLS=OFF
+-DWITH_DOC=OFF
+-DWITH_DOC_MANPAGES=OFF
+-DWITH_TESTS=OFF
+-DDPKG_DATADIR=$TERMUX_PREFIX/share/dpkg
+"
+# -DCMAKE_INSTALL_FULL_LOCALSTATEDIR=$TERMUX_PREFIX
+# -DCACHE_DIR=${TERMUX_CACHE_DIR}/apt
+
+# ubuntu uses instead $PREFIX/lib instead of $PREFIX/libexec to
+# "Work around bug in GNUInstallDirs" (from apt 1.4.8 CMakeLists.txt).
+# Archlinux uses $PREFIX/libexec though, so let's force libexec->lib to
+# get same build result on ubuntu and archlinux.
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+="-DCMAKE_INSTALL_LIBEXECDIR=lib"
+
+TERMUX_PKG_RM_AFTER_INSTALL="
+bin/apt-cdrom
+bin/apt-extracttemplates
+bin/apt-sortpkgs
+etc/apt/apt.conf.d
+lib/apt/methods/cdrom
+lib/apt/methods/mirror*
+lib/apt/methods/rred
+lib/apt/planners/
+lib/apt/solvers/
+lib/dpkg/
+share/man/man1/apt-extracttemplates.1
+share/man/man1/apt-sortpkgs.1
+share/man/man1/apt-transport-mirror.1
+share/man/man8/apt-cdrom.8
+"
+
+# echo apt;exit
+
+termux_step_pre_configure() {
+	# echo what;exit
+	# Certain packages are not safe to build on device because their
+	# build.sh script deletes specific files in $TERMUX_PREFIX.
+	if $TERMUX_ON_DEVICE_BUILD && ! ${TERMUX_SAFE_BUILD-false}; then
+		termux_error_exit "Package '$TERMUX_PKG_NAME' require  --safe for on-device builds"
+	fi
+
+	# Fix i686 builds.
+	CXXFLAGS+=" -Wno-c++11-narrowing"
+
+	# for manpage build
+	local docbook_xsl_version=$(. $TERMUX_SCRIPTDIR/packages/docbook-xsl/build.sh; echo $TERMUX_PKG_VERSION)
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" -DDOCBOOK_XSL=$TERMUX_PREFIX_CLASSICAL/share/xml/docbook/xsl-stylesheets-$docbook_xsl_version-nons"
+}
+
+termux_step_post_configure() {
+	sed -i.old '1s;^;#include <cstdint>\n;' $TERMUX_PKG_SRCDIR/apt-pkg/contrib/strutl.cc
+}
+
+termux_step_post_make_install() {
+	:
+	# local target=$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/etc/apt
+}
+
+termux_step_post_massage() {
+	local target=etc/apt
+	mkdir -p $target
+
+	# no recommend 
+	local_replace_prefix $TERMUX_PKG_BUILDER_DIR/apt.conf.in  $target/apt.conf
+
+	# cert file read error. the rest  is not needed prefix already handles paths
+	if ! ${TERMUX_PKG_PROOT-false}; then
+		mkdir $target/apt.conf.d
+		local_replace_prefix $TERMUX_PKG_BUILDER_DIR/root.conf.in  $target/apt.conf.d/root.conf
+	fi
+
+	mkdir $target/sources.list.d 
+	cp $TERMUX_PKG_BUILDER_DIR/glibc.list $target/sources.list.d/
+
+	mkdir $target/trusted.gpg.d 
+	cp $TERMUX_SCRIPTDIR/packages/termux-keyring/termux-autobuilds.gpg $target/trusted.gpg.d/
+}
+
+local_replace_prefix() {
+	sed -e "s|@TERMUX_PREFIX@|${TERMUX_PREFIX}|g" \
+		-e "s|@TERMUX_CACHE_DIR@|${TERMUX_CACHE_DIR}|g" \
+	$1 > $2
+}

--- a/gpkg/apt/glibc.list
+++ b/gpkg/apt/glibc.list
@@ -1,0 +1,4 @@
+# The glibc termux repository, with cloudflare cache
+deb https://packages-cf.termux.dev/apt/termux-glibc/ glibc stable
+# The glibc termux repository, without cloudflare cache
+# deb https://packages.termux.dev/apt/termux-glibc/ glibc stable

--- a/gpkg/apt/root.conf.in
+++ b/gpkg/apt/root.conf.in
@@ -1,0 +1,16 @@
+// vim:ft=aptconf
+/* vi:set ft=aptconf */
+/* RootDir "@TERMUX_PREFIX@"; */
+/* Dir "@TERMUX_PREFIX@"; */
+/* Dir::Bin::dpkg "bin/dpkg"; */
+/* don't mix cache with bionic */ 
+/* Dir::Cache "@TERMUX_CACHE_DIR@/apt"; */
+/* Dir::Etc "etc/apt"; */
+/* Dir::Etc::sourcelist "/data/data/com.termux/debian/d.sources"; */
+/* Dir::Etc::sourceparts ""; */
+/* Dir::Log "var/log/apt"; */
+/* Dir::State "var/lib/apt"; */
+/* Dir::State::status "../dpkg/status"; */
+/* Dir::State::status "lists/../../dpkg/status"; */
+/* Dir::State::status "@TERMUX_PREFIX@/var/lib/dpkg/status"; */
+/* dpkg::options { "--instdir=@TERMUX_PREFIX@"; }; */

--- a/gpkg/dpkg/another-hardlink.patch
+++ b/gpkg/dpkg/another-hardlink.patch
@@ -1,0 +1,11 @@
+--- archives.c	2025-09-22 12:42:56.058534783 +0300
++++ src/src/main/archives.c	2025-09-22 12:43:12.130534772 +0300
+@@ -434,7 +434,7 @@
+     if (linknode->flags & (FNNF_DEFERRED_RENAME | FNNF_NEW_CONFF))
+       varbuf_add_str(&hardlinkfn, DPKGNEWEXT);
+     varbuf_end_str(&hardlinkfn);
+-    if (link(hardlinkfn.buf, path))
++    if (symlink(hardlinkfn.buf, path))
+       ohshite(_("error creating hard link '%.255s'"), te->name);
+     namenode->newhash = linknode->newhash;
+     debug(dbg_eachfiledetail, "tarobject hardlink digest=%s", namenode->newhash);

--- a/gpkg/dpkg/build.sh
+++ b/gpkg/dpkg/build.sh
@@ -1,0 +1,110 @@
+TERMUX_PKG_HOMEPAGE=https://packages.debian.org/dpkg
+TERMUX_PKG_DESCRIPTION="Debian package management system"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="1.22.6"
+TERMUX_PKG_REVISION=1
+# old tarball are removed in https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SRCURL=git+https://salsa.debian.org/dpkg-team/dpkg.git
+TERMUX_PKG_GIT_BRANCH="${TERMUX_PKG_VERSION}"
+TERMUX_PKG_AUTO_UPDATE=false
+TERMUX_PKG_DEPENDS="bzip2, coreutils, diffutils, gzip, less, libbz2-glibc, liblzma-glibc, libmd-glibc,  tar, xz-utils, zlib-glibc, zstd"
+# libmd-glibc,
+TERMUX_PKG_ANTI_BUILD_DEPENDS="clang"
+TERMUX_PKG_BREAKS="dpkg-dev"
+TERMUX_PKG_REPLACES="dpkg-dev"
+# TERMUX_PKG_ESSENTIAL=true
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+ac_cv_lib_selinux_setexecfilecon=no
+--disable-dselect
+--disable-largefile
+--disable-shared
+dpkg_cv_c99_snprintf=yes
+HAVE_SETEXECFILECON_FALSE=#
+--build=$TERMUX_HOST_PLATFORM
+--host=${TERMUX_ARCH}-linux
+--without-selinux
+DPKG_PAGER=less
+"
+
+TERMUX_PKG_RM_AFTER_INSTALL="
+bin/dpkg-architecture
+bin/dpkg-buildflags
+bin/dpkg-buildpackage
+bin/dpkg-checkbuilddeps
+bin/dpkg-distaddfile
+bin/dpkg-genbuildinfo
+bin/dpkg-genchanges
+bin/dpkg-gencontrol
+bin/dpkg-gensymbols
+bin/dpkg-maintscript-helper
+bin/dpkg-mergechangelogs
+bin/dpkg-name
+bin/dpkg-parsechangelog
+bin/dpkg-scansources
+bin/dpkg-shlibdeps
+bin/dpkg-source
+bin/dpkg-statoverride
+bin/dpkg-vendor
+include
+lib
+share/dpkg
+share/man/man1/dpkg-architecture.1
+share/man/man1/dpkg-buildflags.1
+share/man/man1/dpkg-buildpackage.1
+share/man/man1/dpkg-checkbuilddeps.1
+share/man/man1/dpkg-distaddfile.1
+share/man/man1/dpkg-genbuildinfo.1
+share/man/man1/dpkg-genchanges.1
+share/man/man1/dpkg-gencontrol.1
+share/man/man1/dpkg-gensymbols.1
+share/man/man1/dpkg-maintscript-helper.1
+share/man/man1/dpkg-mergechangelogs.1
+share/man/man1/dpkg-name.1
+share/man/man1/dpkg-parsechangelog.1
+share/man/man1/dpkg-scansources.1
+share/man/man1/dpkg-shlibdeps.1
+share/man/man1/dpkg-source.1
+share/man/man1/dpkg-statoverride.1
+share/man/man1/dpkg-vendor.1
+share/man/man3
+share/man/man5
+share/polkit-1
+"
+TERMUX_PKG_RM_AFTER_INSTALL=
+
+termux_step_pre_configure() {
+	bash autogen
+	# change arm64 to aarch64
+	patch -p1 -i "${TERMUX_PKG_BUILDER_DIR}"/configure.diff
+	perl -p -i -e "s/TERMUX_ARCH/$TERMUX_ARCH/" $TERMUX_PKG_SRCDIR/configure
+	sed -i 's/$req_vars = \$arch_vars.$varname./if ($varname eq "DEB_HOST_ARCH_CPU" or $varname eq "DEB_HOST_ARCH"){ print("'$TERMUX_ARCH'");exit; }; $req_vars = $arch_vars{$varname}/' scripts/dpkg-architecture.pl
+}
+
+1termux_step_make() {
+	# ls $TERMUX_PKG_SRCDIR
+	# bash $TERMUX_PKG_SRCDIR/build-aux/config.guess -h
+	bash $TERMUX_PKG_SRCDIR/build-aux/config.guess 
+	exit
+}
+
+termux_step_post_make_install() {
+:
+}
+
+termux_step_post_massage() {
+
+	 # --instdir=prefix wrapper for future simpler packets with no prefix folder shell 
+	# if ! ${TERMUX_PKG_PROOT-false}; then
+		# mkdir libexec
+		# mv bin/dpkg libexec/
+		# cp  $TERMUX_PKG_BUILDER_DIR/dpkg bin/
+	# fi
+
+	local var=var/lib/dpkg
+	mkdir -p "$var/alternatives"
+	mkdir -p "$var/info"
+	mkdir -p "$var/triggers"
+	mkdir -p "$var/updates"
+}

--- a/gpkg/dpkg/configure.diff
+++ b/gpkg/dpkg/configure.diff
@@ -1,0 +1,21 @@
+diff -u -r ../dpkg-1.21.7/configure ./configure
+--- ../dpkg-1.21.7/configure	2022-04-30 20:54:49.352689537 -0300
++++ ./configure	2022-04-30 20:56:52.770022395 -0300
+@@ -33613,7 +33613,7 @@
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking dpkg cpu type" >&5
+ printf %s "checking dpkg cpu type... " >&6; }
+ 
+-      cpu_type=$(PERL=$PERL ${CONFIG_SHELL-/bin/sh} "$srcdir/build-aux/run-script" scripts/dpkg-architecture.pl -t$host -qDEB_HOST_ARCH_CPU 2>/dev/null)
++      cpu_type=TERMUX_ARCH
+ 
+   if test "x$cpu_type" = "x"
+ then :
+@@ -33662,7 +33662,7 @@
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking dpkg architecture name" >&5
+ printf %s "checking dpkg architecture name... " >&6; }
+ 
+-      dpkg_arch=$(PERL=$PERL ${CONFIG_SHELL-/bin/sh} "$srcdir/build-aux/run-script" scripts/dpkg-architecture.pl -t$host -qDEB_HOST_ARCH 2>/dev/null)
++      dpkg_arch=TERMUX_ARCH
+ 
+   if test "x$dpkg_arch" = "x"
+ then :

--- a/gpkg/dpkg/dbmodify_dont_require_root.patch
+++ b/gpkg/dpkg/dbmodify_dont_require_root.patch
@@ -1,0 +1,14 @@
+diff -u -r ../dpkg-1.17.6/lib/dpkg/dbmodify.c ./lib/dpkg/dbmodify.c
+--- ../dpkg-1.17.6/lib/dpkg/dbmodify.c	2013-12-14 06:36:07.000000000 +0100
++++ ./lib/dpkg/dbmodify.c	2014-02-25 18:12:15.000000000 +0100
+@@ -253,8 +253,10 @@
+   switch (readwritereq) {
+   case msdbrw_needsuperuser:
+   case msdbrw_needsuperuserlockonly:
++#ifndef __ANDROID__
+     if (getuid() || geteuid())
+       ohshit(_("requested operation requires superuser privilege"));
++#endif
+     /* Fall through. */
+   case msdbrw_write: case msdbrw_writeifposs:
+     if (access(dpkg_db_get_dir(), W_OK)) {

--- a/gpkg/dpkg/dpkg
+++ b/gpkg/dpkg/dpkg
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -x
+$PREFIX/glibc/libexec/dpkg --instdir=$PREFIX/glibc --admindir=$PREFIX/glibc/var/lib/dpkg $@

--- a/gpkg/dpkg/lib-dpkg-atomic-file.c.patch
+++ b/gpkg/dpkg/lib-dpkg-atomic-file.c.patch
@@ -1,0 +1,20 @@
+diff -u -r ../dpkg-1.18.2/lib/dpkg/atomic-file.c ./lib/dpkg/atomic-file.c
+--- ../dpkg-1.18.2/lib/dpkg/atomic-file.c	2015-07-12 22:38:47.000000000 -0400
++++ ./lib/dpkg/atomic-file.c	2015-08-25 18:06:51.689715379 -0400
+@@ -90,8 +90,14 @@
+ 
+ 	if (unlink(name_old) && errno != ENOENT)
+ 		ohshite(_("error removing old backup file '%s'"), name_old);
+-	if (link(file->name, name_old) && errno != ENOENT)
+-		ohshite(_("error creating new backup file '%s'"), name_old);
++#ifdef __ANDROID__
++	/* Termux: Use rename(2) since Android does not support hardlinks. */
++	if (rename(file->name, name_old) && errno != ENOENT) {
++#else
++	if (link(file->name, name_old) && errno != ENOENT) {
++#endif
++		ohshite(_("error creating new backup file '%s'"), name_old);
++	}
+ 
+ 	free(name_old);
+ }

--- a/gpkg/dpkg/lib-dpkg-path-remove.c.patch
+++ b/gpkg/dpkg/lib-dpkg-path-remove.c.patch
@@ -1,0 +1,20 @@
+Handle EROFS.  This is since path_remove_tree() will be called with
+       '/data.dpkg-tmp'
+       '/data/data.dpkg-tmp'
+       '/data/data/com.termux.dpkg-tmp'
+       '/data/data/com.termux/files.dpkg-tmp'
+       '/data/data/com.termux/files/usr.dpkg-tmp'
+and the first call will get a EROFS, read-only file system error.
+
+diff -u -r ../dpkg-1.18.2/lib/dpkg/path-remove.c ./lib/dpkg/path-remove.c
+--- ../dpkg-1.18.2/lib/dpkg/path-remove.c	2015-07-30 00:39:24.000000000 -0400
++++ ./lib/dpkg/path-remove.c	2015-08-25 18:04:31.391421421 -0400
+@@ -126,7 +126,7 @@
+ 	debug(dbg_eachfile, "%s '%s'", __func__, pathname);
+ 	if (!rmdir(pathname))
+ 		return; /* Deleted it OK, it was a directory. */
+-	if (errno == ENOENT || errno == ELOOP)
++	if (errno == ENOENT || errno == ELOOP || errno == EROFS)
+ 		return;
+ 	if (errno == ENOTDIR) {
+ 		/* Either it's a file, or one of the path components is. If

--- a/gpkg/dpkg/src-archives.c.patch
+++ b/gpkg/dpkg/src-archives.c.patch
@@ -1,0 +1,73 @@
+diff -u -r src-orig/src/main/archives.c src/src/main/archives.c
+--- src-orig/src/main/archives.c	2024-03-03 01:30:15.000000000 +0000
++++ src/src/main/archives.c	2024-05-05 20:36:54.148725216 +0000
+@@ -394,9 +394,11 @@
+             namenode->statoverride->uid,
+             namenode->statoverride->gid,
+             namenode->statoverride->mode);
++#ifndef __ANDROID__
+     rc = fchown(fd, st->uid, st->gid);
+     if (forcible_nonroot_error(rc))
+       ohshite(_("error setting ownership of '%.255s'"), te->name);
++#endif
+     rc = fchmod(fd, st->mode & ~S_IFMT);
+     if (forcible_nonroot_error(rc))
+       ohshite(_("error setting permissions of '%.255s'"), te->name);
+@@ -509,13 +511,17 @@
+     return; /* Already handled using the file descriptor. */
+ 
+   if (te->type == TAR_FILETYPE_SYMLINK) {
++#ifndef __ANDROID__
+     rc = lchown(path, st->uid, st->gid);
+     if (forcible_nonroot_error(rc))
+       ohshite(_("error setting ownership of symlink '%.255s'"), path);
++#endif
+   } else {
++#ifndef __ANDROID__
+     rc = chown(path, st->uid, st->gid);
+     if (forcible_nonroot_error(rc))
+       ohshite(_("error setting ownership of '%.255s'"), path);
++#endif
+     rc = chmod(path, st->mode & ~S_IFMT);
+     if (forcible_nonroot_error(rc))
+       ohshite(_("error setting permissions of '%.255s'"), path);
+@@ -555,9 +561,11 @@
+     else if (linksize > stab->st_size)
+       ohshit(_("symbolic link '%.250s' size has changed from %jd to %zd"),
+              fn_old, (intmax_t)stab->st_size, linksize);
++#ifndef __ANDROID__
+     else if (linksize < stab->st_size)
+       warning(_("symbolic link '%.250s' size has changed from %jd to %zd"),
+              fn_old, (intmax_t)stab->st_size, linksize);
++#endif
+     linkmatch = strcmp(linkname.buf, te->linkname) == 0;
+     varbuf_destroy(&linkname);
+     if (linkmatch)
+@@ -1053,18 +1061,27 @@
+       else if (linksize > stab.st_size)
+         ohshit(_("symbolic link '%.250s' size has changed from %jd to %zd"),
+                fnamevb.buf, (intmax_t)stab.st_size, linksize);
++#ifndef __ANDROID__
+       else if (linksize < stab.st_size)
+         warning(_("symbolic link '%.250s' size has changed from %jd to %zd"),
+                fnamevb.buf, (intmax_t)stab.st_size, linksize);
++#endif
+       if (symlink(symlinkfn.buf,fnametmpvb.buf))
+         ohshite(_("unable to make backup symlink for '%.255s'"), ti->name);
++#ifndef __ANDROID__
+       rc = lchown(fnametmpvb.buf, stab.st_uid, stab.st_gid);
+       if (forcible_nonroot_error(rc))
+         ohshite(_("unable to chown backup symlink for '%.255s'"), ti->name);
++#endif
+       tarobject_set_se_context(fnamevb.buf, fnametmpvb.buf, stab.st_mode);
+     } else {
+       debug(dbg_eachfiledetail, "tarobject nondirectory, 'link' backup");
++#ifdef __ANDROID__
++      /* Android does not support hardlinks. */
++      if (rename(fnamevb.buf,fnametmpvb.buf))
++#else
+       if (link(fnamevb.buf,fnametmpvb.buf))
++#endif
+         ohshite(_("unable to make backup link of '%.255s' before installing new version"),
+                 ti->name);
+     }

--- a/gpkg/dpkg/src-configure.c.patch
+++ b/gpkg/dpkg/src-configure.c.patch
@@ -1,0 +1,16 @@
+diff -u -r ../dpkg-1.18.15/src/configure.c ./src/configure.c
+--- ../dpkg-1.18.15/src/configure.c	2016-11-11 22:18:40.000000000 -0500
++++ ./src/main/configure.c	2016-12-03 16:32:43.719508056 -0500
+@@ -497,8 +497,10 @@
+ 			        pkg_name(pkg, pnaw_nonambig), cdr2.buf,
+ 			        strerror(errno));
+ 		if (!(what & CFOF_USER_DEL))
+-			if (link(cdr.buf, cdr2.buf))
+-				warning(_("%s: failed to link '%.250s' to '%.250s': %s"),
++			/** Termux modification: Use rename(2) instead of link(2), to avoid hard
++			    links which does not work on Android 6.0 or later. */
++			if (rename(cdr.buf, cdr2.buf))
++				warning(_("%s: failed to rename '%.250s' to '%.250s': %s"),
+ 				        pkg_name(pkg, pnaw_nonambig), cdr.buf,
+ 				        cdr2.buf, strerror(errno));
+ 		/* Fall through. */

--- a/gpkg/dpkg/src-statoverride-main.c.patch
+++ b/gpkg/dpkg/src-statoverride-main.c.patch
@@ -1,0 +1,15 @@
+diff --color -uNr ../dpkg-1.21.8/src/statoverride/main.c ./src/statoverride/main.c
+--- ../dpkg-1.21.8/src/statoverride/main.c	2022-05-24 14:36:59.000000000 -0300
++++ ./src/statoverride/main.c	2022-05-31 07:39:44.829552700 -0300
+@@ -188,9 +188,11 @@
+ {
+ 	int rc;
+ 
++#ifndef __ANDROID__
+ 	rc = chown(filename, filestat->uid, filestat->gid);
+ 	if (forcible_nonroot_error(rc) < 0)
+ 		ohshite(_("error setting ownership of '%.255s'"), filename);
++#endif
+ 	rc = chmod(filename, filestat->mode & ~S_IFMT);
+ 	if (forcible_nonroot_error(rc) < 0)
+ 		ohshite(_("error setting permissions of '%.255s'"), filename);

--- a/gpkg/libmd/build.sh
+++ b/gpkg/libmd/build.sh
@@ -1,0 +1,14 @@
+TERMUX_PKG_HOMEPAGE=https://www.hadrons.org/software/libmd/
+TERMUX_PKG_DESCRIPTION="Message Digest functions from BSD systems"
+# Licenses: BSD 3-Clause, BSD 2-Clause, ISC, Beerware, Public Domain
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_LICENSE_FILE="COPYING"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION=1.1.0
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://archive.hadrons.org/software/libmd/libmd-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--build=$TERMUX_HOST_PLATFORM
+--host=${TERMUX_ARCH}-linux
+"

--- a/gpkg/xxhash/build.sh
+++ b/gpkg/xxhash/build.sh
@@ -1,0 +1,27 @@
+TERMUX_PKG_HOMEPAGE=https://cyan4973.github.io/xxHash/
+TERMUX_PKG_DESCRIPTION="Extremely fast non-cryptographic hash algorithm"
+TERMUX_PKG_LICENSE="BSD, GPL-2.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="0.8.3"
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/Cyan4973/xxHash/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=aae608dfe8213dfd05d909a57718ef82f30722c392344583d3f39050c7f29a80
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_EXTRA_MAKE_ARGS="V=1 VERBOSE=1"
+
+termux_step_post_configure() {
+	sed -i 's,$(shell uname),Linux,' $TERMUX_PKG_SRCDIR/Makefile
+}
+
+termux_step_post_massage1() {
+	# Do not forget to bump revision of reverse dependencies and rebuild them
+	# after SOVERSION is changed.
+	local _SOVERSION_GUARD_FILES="lib/libxxhash.so.0"
+	local f
+	for f in ${_SOVERSION_GUARD_FILES}; do
+		if [ ! -e "${f}" ]; then
+			termux_error_exit "SOVERSION guard check failed."
+		fi
+	done
+}


### PR DESCRIPTION
vim:ft=text

  # update cert packet broken in glibc

after copying code from src/methods/connect.cc it seems the cert packet is broken

g++ tls.cc -lgnutls && a.out
strace a.out |& ack cert

in bionic

openat(AT_FDCWD, "/data/data/com.termux/files/usr/etc/tls/cert.pem", O_RDONLY|O_CLOEXEC) = 3

in glibc

newfstatat(AT_FDCWD, "/data/data/com.termux/files/usr/glibc/etc/ca-certificates/trust-source", 0x7fd68d7008, 0) = -1 ENOENT (No such file or directory)

vim tls.cc
  #include <iostream>
  #include <cstddef>
  #include <gnutls/gnutls.h>
  #include <gnutls/x509.h>
using namespace std;
int main() {
	int err;
   gnutls_certificate_credentials_t credentials;
   int r = gnutls_certificate_allocate_credentials(&credentials);
      err = gnutls_certificate_set_x509_system_trust(credentials);
	cout << "trust: " << err << endl;
	return 0;
}

 # partly  resolved but mysterious cert file read error even in proot

 this is solved by specifying the cert file in apt.conf and might not interest you further  but I had to investigate this . I can't understand why this happens even in proot . I even created a new --proot build in john-peterson/termux-packages@proot to build with blank prefix if that is the error

i can't find this among any bionic patches . I removed all patches and
this is the only problem it seems to stumble on permission of cert file

disable path fix before test

mv -iv $G/etc/apt/apt.conf/{,.bak}

this print nothing

apt-config dump|ack CaInfo

this works

apt -c $G/etc/apt/apt.conf.bak update

apt -o Acquire::https::CaInfo=$G/etc/ssl/certs/ca-certificates.crt update

but strace doesn't pick up the file read

strace apt ... |& ack cert

this fail

apt update
W: http://packages.termux.dev/apt/termux-glibc/dists/glibc/InRelease: No system certificates available. Try installing ca-certificates.

even in proot update fails

G=/data/data/com.termux/files/usr/glibc
proot ... -r $G /bin/bash
apt update
same error

and this fail how is that possible

whoops that was a typo . CaInf missing o. it also works when typed correct

apt -o Acquire::https::CaInf=/etc/ca-certificates/cacert.pem update

maybe some thing with proot or symlink permission locked to 777

ls -l /etc/ca-certificates/cacert.pem
-rw-r--r-- 1 u0_a206 u0_a206 234847 Oct  4  2024 /etc/ca-certificates/cacert.pem

stat /etc/ca-certificates/cacert.pem
Access: (0644/-rw-r--r--)  Uid: (10206/ u0_a206)   Gid: (10206/ u0_a206)

  # only for glibc repos

notice don't drag bionic lists into this apt cache . the whole purpose is to have only glibc repos here

if a dependency is missing copy it to glibc from bionic don't add the bionic repo! or manually add it to the status file until the list is updated online

 in john-peterson/termux-packages@proot I propose that the -glibc suffix is dropped from all packet names since they should not mix with musl or bionic packets

if anyone still want to mix bionic and glibc packets  against all odds . the packet can still be distinguished by the suite name

for bionic

apt install abc/stable

for glibc

apt install abc/glibc

but I don't recommend this to anyone

 # my view on all this . no more use less non proot or bionic patches from me

I am not fixing anything that works in proot  glibc or debian anymore  have already done that for years for no purpose

I am even creating a new proot repo to remove all path patches also . this recipe already has all path patches removed

 # path patches removed

 all path patches are removed compared to bionic build . and it works anyway with only prefix build flag . I have included root.conf for potential path fixes if necessary . but I did not need any of them

 this build recipe also works with the new --proot build flag and create a pristine build with no prefix or special paths

the proot build also restore the --root flag . in this build --root=abc means abc/prefix . dpkg append prefix to root flag

if dpkg is built with --prefix the work around is this that does not append the prefix

dpkg --root=abc <- broken . is actually abc/prefix

dpkg --admindir=$root/var/lib/dpkg --instdir=$root <- works no prefix inserted
--admindir can be omitted because it's prefix/var/lib/dpkg by default . --instdir is not prefix by default

 # add --installdir=prefix if glibc suffix removed

 if the prefix shell  is removed from packets add --installdir=prefix to dpkg wrapper

I have proposed this in john-peterson/termux-packages@proot for  simplicity  . simpler build logic and packets and dpkg -c output with no prefix in packet files

---

side note about copying debian packets to termux . that I asked about before

 ## copy Debian packet to termux

 the build.sh file is called debian/control debian/rules and they are scattered all over the web . there is no single debian build repo like this that contain all recipes . the Debian build recipes are all over the place impossible to find them in one place

 after endless searching I found the Debian build system for R. it's in the same repo as the app. it seems like they expect the app to provide it

~~~
https://salsa.debian.org/edd/r-base

ack "Depends" debian/control|head -1
Build-Depends: gcc (>= 4:4.9.2-2), g++ (>= 4:4.9.2-2), gfortran (>= 4:4.9.2-2), libblas-dev, liblapack-dev, tcl8.6-dev, tk8.6-dev, bison, groff-base, libncur...

head -2 debian/rules

dpkg-buildpackage -B
~~~

this packet already works with debian proot but I will try to copy the rules file to build.sh as an exercise to learn the debian build system

it will require many new packets that are missing . if they fail to build I have to find the debian/rules for them also in a separate location unless it's in the source folder  . if that will help finding the broken build flag