### PR TITLE
new packet tmux

### DIFF
--- a/gpkg/tmux/0002-left.patch
+++ b/gpkg/tmux/0002-left.patch
@@ -1,0 +1,127 @@
+From cd0b1749a1aa600874f119b765e8082a53abbaf2 Mon Sep 17 00:00:00 2001
+From: John Peterson <jpeterson57@gmail.com>
+Date: Tue, 27 Jan 2026 03:08:08 +1100
+Subject: [PATCH 2/2] left
+
+---
+ key-string.c    |  2 ++
+ mode-tree.c     |  2 ++
+ server-client.c | 28 +++++++++++++++++++++++++++-
+ tmux.h          |  8 +++++++-
+ 4 files changed, 38 insertions(+), 2 deletions(-)
+
+diff --git a/key-string.c b/key-string.c
+index a171b0c..2911b5a 100644
+--- a/key-string.c
++++ b/key-string.c
+@@ -162,6 +162,8 @@ static const struct {
+ 	KEYC_MOUSE_STRING(MOUSEDRAGEND11, MouseDragEnd11),
+ 	KEYC_MOUSE_STRING(WHEELUP, WheelUp),
+ 	KEYC_MOUSE_STRING(WHEELDOWN, WheelDown),
++	KEYC_MOUSE_STRING(WHEELLEFT, WheelLeft),
++	KEYC_MOUSE_STRING(WHEELRIGHT, WheelRight),
+ 	KEYC_MOUSE_STRING(SECONDCLICK1, SecondClick1),
+ 	KEYC_MOUSE_STRING(SECONDCLICK2, SecondClick2),
+ 	KEYC_MOUSE_STRING(SECONDCLICK3, SecondClick3),
+diff --git a/mode-tree.c b/mode-tree.c
+index 24cbea0..67843ad 100644
+--- a/mode-tree.c
++++ b/mode-tree.c
+@@ -1223,6 +1223,7 @@ mode_tree_key(struct mode_tree_data *mtd, struct client *c, key_code *key,
+ 		break;
+ 	case KEYC_LEFT:
+ 	case 'h':
++	case KEYC_WHEELLEFT_PANE:
+ 	case '-':
+ 		if (line->flat || !current->expanded)
+ 			current = current->parent;
+@@ -1236,6 +1237,7 @@ mode_tree_key(struct mode_tree_data *mtd, struct client *c, key_code *key,
+ 		break;
+ 	case KEYC_RIGHT:
+ 	case 'l':
++	case KEYC_WHEELRIGHT_PANE:
+ 	case '+':
+ 		if (line->flat || current->expanded)
+ 			mode_tree_down(mtd, 0);
+diff --git a/server-client.c b/server-client.c
+index 30cf528..3cd9d92 100644
+--- a/server-client.c
++++ b/server-client.c
+@@ -1288,7 +1288,7 @@ have_event:
+ 				key = KEYC_WHEELUP_STATUS_DEFAULT;
+ 			if (where == BORDER)
+ 				key = KEYC_WHEELUP_BORDER;
+-		} else {
++		} else if (MOUSE_BUTTONS(b) == MOUSE_WHEEL_DOWN) {
+ 			if (where == PANE)
+ 				key = KEYC_WHEELDOWN_PANE;
+ 			if (where == STATUS)
+@@ -1301,6 +1301,32 @@ have_event:
+ 				key = KEYC_WHEELDOWN_STATUS_DEFAULT;
+ 			if (where == BORDER)
+ 				key = KEYC_WHEELDOWN_BORDER;
++		} else if (MOUSE_BUTTONS(b) == MOUSE_WHEEL_LEFT) {
++			if (where == PANE)
++				key = KEYC_WHEELLEFT_PANE;
++			if (where == STATUS)
++				key = KEYC_WHEELLEFT_STATUS;
++			if (where == STATUS_LEFT)
++				key = KEYC_WHEELLEFT_STATUS_LEFT;
++			if (where == STATUS_RIGHT)
++				key = KEYC_WHEELLEFT_STATUS_RIGHT;
++			if (where == STATUS_DEFAULT)
++				key = KEYC_WHEELLEFT_STATUS_DEFAULT;
++			if (where == BORDER)
++				key = KEYC_WHEELLEFT_BORDER;
++		} else if (MOUSE_BUTTONS(b) == MOUSE_WHEEL_RIGHT) {
++			if (where == PANE)
++				key = KEYC_WHEELRIGHT_PANE;
++			if (where == STATUS)
++				key = KEYC_WHEELRIGHT_STATUS;
++			if (where == STATUS_RIGHT)
++				key = KEYC_WHEELRIGHT_STATUS_LEFT;
++			if (where == STATUS_RIGHT)
++				key = KEYC_WHEELRIGHT_STATUS_RIGHT;
++			if (where == STATUS_DEFAULT)
++				key = KEYC_WHEELRIGHT_STATUS_DEFAULT;
++			if (where == BORDER)
++				key = KEYC_WHEELRIGHT_BORDER;
+ 		}
+ 		break;
+ 	case UP:
+diff --git a/tmux.h b/tmux.h
+index e08ed02..0ec9f23 100644
+--- a/tmux.h
++++ b/tmux.h
+@@ -303,6 +303,8 @@ enum {
+ 	KEYC_MOUSE_KEY(MOUSEDRAGEND11),
+ 	KEYC_MOUSE_KEY(WHEELUP),
+ 	KEYC_MOUSE_KEY(WHEELDOWN),
++	KEYC_MOUSE_KEY(WHEELLEFT),
++	KEYC_MOUSE_KEY(WHEELRIGHT),
+ 	KEYC_MOUSE_KEY(SECONDCLICK1),
+ 	KEYC_MOUSE_KEY(SECONDCLICK2),
+ 	KEYC_MOUSE_KEY(SECONDCLICK3),
+@@ -1426,6 +1428,8 @@ RB_HEAD(sessions, session);
+ /* Mouse wheel type. */
+ #define MOUSE_WHEEL_UP 64
+ #define MOUSE_WHEEL_DOWN 65
++#define MOUSE_WHEEL_LEFT 66
++#define MOUSE_WHEEL_RIGHT 67
+ 
+ /* Mouse button type. */
+ #define MOUSE_BUTTON_1 0
+@@ -1442,7 +1446,9 @@ RB_HEAD(sessions, session);
+ #define MOUSE_BUTTONS(b) ((b) & MOUSE_MASK_BUTTONS)
+ #define MOUSE_WHEEL(b) \
+ 	(((b) & MOUSE_MASK_BUTTONS) == MOUSE_WHEEL_UP || \
+-	 ((b) & MOUSE_MASK_BUTTONS) == MOUSE_WHEEL_DOWN)
++	 ((b) & MOUSE_MASK_BUTTONS) == MOUSE_WHEEL_DOWN || \
++	 ((b) & MOUSE_MASK_BUTTONS) == MOUSE_WHEEL_LEFT || \
++	 ((b) & MOUSE_MASK_BUTTONS) == MOUSE_WHEEL_RIGHT)
+ #define MOUSE_DRAG(b) ((b) & MOUSE_MASK_DRAG)
+ #define MOUSE_RELEASE(b) (((b) & MOUSE_MASK_BUTTONS) == 3)
+ 
+-- 
+2.47.1
+

--- a/gpkg/tmux/build.sh
+++ b/gpkg/tmux/build.sh
@@ -1,0 +1,44 @@
+TERMUX_PKG_HOMEPAGE=https://tmux.github.io/
+TERMUX_PKG_DESCRIPTION="Terminal multiplexer"
+TERMUX_PKG_LICENSE="ISC"
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
+TERMUX_PKG_VERSION="3.5a"
+TERMUX_PKG_SRCURL=https://github.com/tmux/tmux/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=49e68b41dec0bf408990160ee12fa29b06dee8f74c1f0b4b71c9d2a1477dd910
+TERMUX_PKG_AUTO_UPDATE=true
+# Link against libandroid-support for wcwidth(), see https://github.com/termux/termux-packages/issues/224
+TERMUX_PKG_DEPENDS="ncurses, libevent"
+# Set default TERM to screen-256color, see: https://raw.githubusercontent.com/tmux/tmux/3.3/CHANGES
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+--disable-static
+--with-TERM=screen-256color 
+--enable-sixel"
+TERMUX_PKG_EXTRA_MAKE_ARGS="
+"
+# CFLAGS+=-D_PATH_TMP=$TERMUX_PREFIX/tmp
+# CFLAGS+=-D_PATH_TMP=$TMPDIR
+# CFLAGS+=-DTMUX_SOCK=$TMUX_TMPDIR:$TERMUX_PREFIX/var/run
+TERMUX_PKG_BUILD_IN_SRC=true
+
+TERMUX_PKG_CONFFILES="etc/tmux.conf etc/profile.d/tmux.sh"
+
+termux_step_pre_configure() {
+	./autogen.sh
+}
+
+termux_step_post_make_install() {
+	# cp "$TERMUX_PKG_BUILDER_DIR"/tmux.conf "$TERMUX_PREFIX"/etc/tmux.conf
+
+	mkdir -p "$TERMUX_PREFIX"/etc/profile.d
+	echo "export TMUX_TMPDIR=$TERMUX_PREFIX/var/run" > "$TERMUX_PREFIX"/etc/profile.d/tmux.sh
+
+	mkdir -p "$TERMUX_PREFIX"/share/bash-completion/completions
+	termux_download \
+		https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/homebrew_1.0.0/completions/tmux \
+		"$TERMUX_PREFIX"/share/bash-completion/completions/tmux \
+		05e79fc1ecb27637dc9d6a52c315b8f207cf010cdcee9928805525076c9020ae
+}
+
+termux_step_post_massage() {
+	mkdir -p "${TERMUX_PKG_MASSAGEDIR}/${TERMUX_PREFIX}"/var/run
+}


### PR DESCRIPTION
I am moving to glibc as default and I needed a new patch

and as usual the bionic build is broken the service crashed for all bind and list keys command

I just gave up and used glibc

 # it's still using bionic bash

even when I launch this from glibc/bin/bash it ends up inside bin/bash the bionic bash

I can't fix every thing now I just want to try my new mouse wheel patch with tmux-better-mouse-mode

i print the shell because I have so many different bash for debian Ubuntu etc

~~~
vim ~/.bashrc
cmd=$($p/readlink -f /proc/$$/exe)
echo $cmd
~~~
