### PR TITLE
add autoconf

### DIFF
--- a/gpkg/autoconf/autom4te.in.patch
+++ b/gpkg/autoconf/autom4te.in.patch
@@ -1,0 +1,11 @@
+--- ./bin/autom4te.in.orig	2021-08-19 21:45:43.203065990 +0200
++++ ./bin/autom4te.in	2021-08-19 21:46:46.779739045 +0200
+@@ -94,7 +94,7 @@
+ my $m4 = $ENV{"M4"} || '@M4@';
+ # Some non-GNU m4's don't reject the --help option, so give them /dev/null.
+ fatal "need GNU m4 1.4 or later: $m4"
+-  if system "$m4 --help </dev/null 2>&1 | grep reload-state >/dev/null";
++  if system "$m4 --help 2>&1 | grep reload-state >/dev/null";
+ 
+ # Set some high recursion limit as the default limit, 250, has already
+ # been hit with AC_OUTPUT.  Don't override the user's choice.

--- a/gpkg/autoconf/build.sh
+++ b/gpkg/autoconf/build.sh
@@ -1,0 +1,20 @@
+TERMUX_PKG_HOMEPAGE=https://www.gnu.org/software/autoconf/autoconf.html
+TERMUX_PKG_DESCRIPTION="Creator of shell scripts to configure source code packages"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_MAINTAINER="@termux"
+TERMUX_PKG_VERSION="2.72"
+TERMUX_PKG_SRCURL=https://mirrors.kernel.org/gnu/autoconf/autoconf-${TERMUX_PKG_VERSION}.tar.xz
+TERMUX_PKG_SHA256=ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a
+TERMUX_PKG_AUTO_UPDATE=true
+TERMUX_PKG_DEPENDS="m4, make, perl"
+TERMUX_PKG_PLATFORM_INDEPENDENT=true
+TERMUX_PKG_GROUPS="base-devel"
+
+termux_step_post_get_source() {
+	perl -p -i -e "s|/bin/sh|$TERMUX_PREFIX/bin/sh|" lib/*/*.m4
+}
+
+termux_step_post_massage() {
+	perl -p -i -e "s|/usr/bin/m4|$TERMUX_PREFIX/bin/m4|" bin/*
+	perl -p -i -e "s|CONFIG_SHELL-/bin/sh|CONFIG_SHELL-$TERMUX_PREFIX/bin/sh|" bin/autoconf
+}

--- a/gpkg/autoconf/fix-tmpdir.patch
+++ b/gpkg/autoconf/fix-tmpdir.patch
@@ -1,0 +1,24 @@
+diff -uNr autoconf-2.70/lib/autoconf/specific.m4 autoconf-2.70.mod/lib/autoconf/specific.m4
+--- autoconf-2.70/lib/autoconf/specific.m4	2020-12-07 23:24:16.000000000 +0200
++++ autoconf-2.70.mod/lib/autoconf/specific.m4	2020-12-11 17:51:41.321805117 +0200
+@@ -199,7 +199,7 @@
+ #      /tmp		where it might want to write temporary files
+ #      /var/tmp		likewise
+ #      /usr/tmp		likewise
+-for ac_dir in . "$TMPDIR" /tmp /var/tmp /usr/tmp "$prefix/lib" "$exec_prefix/lib"; do
++for ac_dir in . "$TMPDIR" @TERMUX_PREFIX@/tmp "$prefix/lib" "$exec_prefix/lib"; do
+   # Skip $TMPDIR if it is empty or bogus, and skip $exec_prefix/lib
+   # in the usual case where exec_prefix is '${prefix}'.
+   case $ac_dir in #(
+diff -uNr autoconf-2.70/lib/m4sugar/m4sh.m4 autoconf-2.70.mod/lib/m4sugar/m4sh.m4
+--- autoconf-2.70/lib/m4sugar/m4sh.m4	2020-12-02 17:26:23.000000000 +0200
++++ autoconf-2.70.mod/lib/m4sugar/m4sh.m4	2020-12-11 17:51:22.721606959 +0200
+@@ -1705,7 +1705,7 @@
+ # it is a documented part of the public API and must not be changed.
+ m4_define([AS_TMPDIR],
+ [# Create a (secure) tmp directory for tmp files.
+-m4_if([$2], [], [: "${TMPDIR:=/tmp}"])
++m4_if([$2], [], [: "${TMPDIR:=@TERMUX_PREFIX@/tmp}"])
+ {
+   tmp=`(umask 077 && mktemp -d "m4_default([$2],
+     [$TMPDIR])/$1XXXXXX") 2>/dev/null` &&


### PR DESCRIPTION
if you don't have bionic in path

I am trying to create a stand alone glibc root

it's a matter of preference if you want to include all roots in path

I some times have fall backs to bionic and some times not

when I use Ubuntu or glibc proot I some times have only /bin in path to be sure nothing extraneous creeps in to the build
