### PR TITLE
fix(glibc-runner): quote $@ so binary args containing spaces aren't split

### DIFF
--- a/gpkg/glibc-runner/glibc-runner
+++ b/gpkg/glibc-runner/glibc-runner
@@ -2,4 +2,4 @@
 
 # version: 2.0
 
-source @TERMUX_PREFIX_CLASSICAL@/opt/glibc-runner/glibc-runner.sh $@
+source @TERMUX_PREFIX_CLASSICAL@/opt/glibc-runner/glibc-runner.sh "$@"

--- a/gpkg/glibc-runner/glibc-runner.sh
+++ b/gpkg/glibc-runner/glibc-runner.sh
@@ -271,9 +271,9 @@ if [ "${GLIBC_RUNNER_RUN_SHELL}" = "true" ]; then
 else
 	if [ -n "$1" ]; then
 		if [ "${DISABLE_DYNAMIC_LINKER}" = "true" ]; then
-			exec $(_glibc-runner_debug) $@
+			exec $(_glibc-runner_debug) "$@"
 		elif [ "${GLIBC_RUNNER_RUN_CONFIGURE}" = "false" ]; then
-			exec $(_glibc-runner_debug) ld.so $@
+			exec $(_glibc-runner_debug) ld.so "$@"
 		fi
 	fi
 fi


### PR DESCRIPTION
## Problem

Fixes #385.

`glibc-runner.sh` launches the target binary with an **unquoted `$@`**, and the `glibc-runner` launcher `source`s the script the same way. Unquoted `$@` undergoes word splitting, so a single quoted argument containing spaces reaches the binary as multiple argv entries.

`gpkg/glibc-runner/glibc-runner.sh` (lines 274, 276):
```bash
exec $(_glibc-runner_debug) $@
exec $(_glibc-runner_debug) ld.so $@
```
`gpkg/glibc-runner/glibc-runner` (line 5):
```bash
source @TERMUX_PREFIX_CLASSICAL@/opt/glibc-runner/glibc-runner.sh $@
```

## Reproduction

Any glibc CLI given a quoted multi-word argument. With AWS CLI v2 (a glibc binary run via `grun`):

```bash
grun ~/.local/aws-cli/aws/dist/aws ce get-cost-and-usage \
  --filter '{"Dimensions":{"Key":"SERVICE","Values":["Amazon Relational Database Service"]}}' ...
# aws: [ERROR]: Unknown options: Database, Service"]}}, Relational
```

The shell passes the value as a single argument (argc verified); the split happens inside glibc-runner at the unquoted expansion.

## Fix

Quote the expansions so argv boundaries are preserved:

```bash
exec $(_glibc-runner_debug) "$@"
exec $(_glibc-runner_debug) ld.so "$@"
source @TERMUX_PREFIX_CLASSICAL@/opt/glibc-runner/glibc-runner.sh "$@"
```

## Verification

Patched both files on-device (`glibc-runner` 2.0-3) and re-ran the failing command — the multi-word `--filter` value is now received intact and the call succeeds. No-arg `grun` (help), `grun -s` (shell), and space-free commands continue to work unchanged.